### PR TITLE
Final strategies

### DIFF
--- a/core/static/canvas.js
+++ b/core/static/canvas.js
@@ -662,5 +662,5 @@ function displayTotalTime(totalTime) {
     ctx.font = "16px Courier New";
     ctx.textAlign = "right";
     ctx.fillStyle = "white";
-    ctx.fillText("Time: " + Math.floor(totalTime/100) + " h", totalTimeX, totalTimeY);
+    ctx.fillText("Time: " + Math.floor(totalTime/100) + " h", totalTimeX, totalTimeY); // floor and not round
 }

--- a/core/static/canvas.js
+++ b/core/static/canvas.js
@@ -662,5 +662,5 @@ function displayTotalTime(totalTime) {
     ctx.font = "16px Courier New";
     ctx.textAlign = "right";
     ctx.fillStyle = "white";
-    ctx.fillText("Time: " + Math.round(totalTime/100) + " h", totalTimeX, totalTimeY);
+    ctx.fillText("Time: " + Math.floor(totalTime/100) + " h", totalTimeX, totalTimeY);
 }

--- a/core/static/main.js
+++ b/core/static/main.js
@@ -485,7 +485,7 @@ function generateManeuverInfo(orbits, burns, totalDeltaVList, totalDeltaTList, s
 
     createLine("Optimization Objective", "Save the most " + (optimization ? "fuel" : "time"));
     createLine("Total Δv", totalDeltaVList[stratId].toLocaleString() + " m/s (proportional to amount of fuel used)");
-    createLine("Total Δt", formatTime(totalDeltaTList[stratId]) + " (time spent in the transfer orbit(s))");
+    createLine("Total Δt", formatTime(totalDeltaTList[stratId]) + " (time spent in initial and transfer orbits)");
     createLine("Number of Burns", burns.length);
     createLine("Number of Transfer Orbits", burns.length - 1);
     info.innerHTML += '<br>';

--- a/core/static/main.js
+++ b/core/static/main.js
@@ -331,7 +331,7 @@ function generateManeuverInfo(orbits, burns, totalDeltaVList, totalDeltaTList, s
     velocityChart = new Chart(velocityChartCtx, {
         type: 'bar',
         data: {
-          labels: ['1', '2', '3', '4'],
+          labels: ['1', '2', '3', '4', '5', '6', '7', '8'],
           datasets: [{
             label: 'Total Δv',
             data: totalDeltaVList,
@@ -400,7 +400,7 @@ function generateManeuverInfo(orbits, burns, totalDeltaVList, totalDeltaTList, s
     timeChart = new Chart(timeChartCtx, {
         type: 'bar',
         data: {
-          labels: ['1', '2', '3', '4'],
+          labels: ['1', '2', '3', '4', '5', '6', '7', '8'],
           datasets: [{
             label: 'Total Δt',
             data: totalDeltaTList,

--- a/core/static/main.js
+++ b/core/static/main.js
@@ -483,7 +483,7 @@ function generateManeuverInfo(orbits, burns, totalDeltaVList, totalDeltaTList, s
     stratAlgHTML += '</div>';
     info.innerHTML += stratAlgHTML;
 
-    createLine("Optimization Objective", "Save the most " + (optimization ? "fuel" : "time"));
+    createLine("Optimization Objective", "Minimize " + (optimization ? "fuel" : "time"));
     createLine("Total Δv", totalDeltaVList[stratId].toLocaleString() + " m/s (proportional to amount of fuel used)");
     createLine("Total Δt", formatTime(totalDeltaTList[stratId]) + " (time spent in initial and transfer orbits)");
     createLine("Number of Burns", burns.length);

--- a/core/utils.py
+++ b/core/utils.py
@@ -393,8 +393,8 @@ def process_maneuver_data(start_orbit: dict, end_orbit: dict, optimization) -> d
     total_delta_t_list = [output['total_delta_t'] for output in strat_outputs]
 
     # test strategies
-    test_id = 6
-    strat_id, best_strat = test_id, strat_outputs[test_id]
+    #test_id = 6
+    #strat_id, best_strat = test_id, strat_outputs[test_id]
 
     max_length, earth_pos = max_length_earth_pos(best_strat['orbits']).values()
     return {"orbits": best_strat['orbits'], "burns": best_strat['burns'], "max_length": max_length, 

--- a/core/utils.py
+++ b/core/utils.py
@@ -393,8 +393,8 @@ def process_maneuver_data(start_orbit: dict, end_orbit: dict, optimization) -> d
     total_delta_t_list = [output['total_delta_t'] for output in strat_outputs]
 
     # test strategies
-    #test_id = 6
-    #strat_id, best_strat = test_id, strat_outputs[test_id]
+    # test_id = 6
+    # strat_id, best_strat = test_id, strat_outputs[test_id]
 
     max_length, earth_pos = max_length_earth_pos(best_strat['orbits']).values()
     return {"orbits": best_strat['orbits'], "burns": best_strat['burns'], "max_length": max_length, 

--- a/core/utils.py
+++ b/core/utils.py
@@ -224,12 +224,12 @@ def process_maneuver_data(start_orbit: dict, end_orbit: dict, optimization) -> d
                     
                     if (round(periapsis(orbits[-1])) != round(apoapsis(orbits[-1]))):
                         orbits[-1]["end_arg"] = math.pi
-                        if (apoapsis(orbits[-1]) < apoapsis(end_orbit)): 
+                        if (apoapsis(orbits[-1]) <= apoapsis(end_orbit)): 
                             newOrbit["arg"] = normalize_angle(orbits[-1]["arg"] + math.pi) 
                         else: 
                             newOrbit["arg"] = orbits[-1]["arg"]
 
-                    if (apoapsis(orbits[-1]) < apoapsis(end_orbit)): # < and not <= because if circle, it should start by default at startArg of 0
+                    if (apoapsis(orbits[-1]) <= apoapsis(end_orbit)):
                         newOrbit["ecc"] = eccentricity(apoapsis(orbits[-1]), apoapsis(end_orbit))
                         newOrbit["start_arg"] = 0
                     else:
@@ -257,12 +257,12 @@ def process_maneuver_data(start_orbit: dict, end_orbit: dict, optimization) -> d
                     
                     if (round(periapsis(orbits[-1])) != round(apoapsis(orbits[-1]))):
                         orbits[-1]["end_arg"] = math.pi
-                        if (apoapsis(orbits[-1]) < periapsis(end_orbit)):
+                        if (apoapsis(orbits[-1]) <= periapsis(end_orbit)):
                             newOrbit["arg"] = normalize_angle(orbits[-1]["arg"] + math.pi)
                         else: 
                             newOrbit["arg"] = orbits[-1]["arg"]
 
-                    if (apoapsis(orbits[-1]) < periapsis(end_orbit)):
+                    if (apoapsis(orbits[-1]) <= periapsis(end_orbit)):
                         newOrbit["ecc"] = eccentricity(apoapsis(orbits[-1]), periapsis(end_orbit))
                         newOrbit["start_arg"] = 0
                     else:


### PR DESCRIPTION
Added 4 more strategies. During testing, there are indeed many cases where these 4 strategies are more fuel or time efficient. Since the orbits' axis can never be more than 11 times greater than another, adding bi elliptic transfers would be useless. These should be the 4 last strategies needed to find the most fuel or time efficient coplanar orbital maneuvers.